### PR TITLE
add news item about jim and trevor

### DIFF
--- a/lecture_site/news.rst
+++ b/lecture_site/news.rst
@@ -4,6 +4,18 @@
 News & Announcements
 *************************
 
+23-May-2017
+-----------
+
+QuantEcon is sponsoring `Jim Savage <https://modernstatisticalworkflow.blogspot.com.au/>`__  to present a workshop on modern statistical workflow and bayesian modeling in  `Stan <http://mc-stan.org/>__`. The workshop will be held at the Australian  National University on 19 June. For more information, please see `here <https://quantecon.org/bayesian-workshop-2017.html>`__.
+
+
+22-May-2017
+-----------
+
+QuantEcon welcomes our newest member, `Trevor Lyon <https://github.com/tlyon3>`__,  who is currently visiting the Australian National University in Canberra.  Trevor is an undergraduate computer science student at Brigham Young University.  He will be spending the summer working on various QuantEcon projects,  including our new notebook publishing site.
+
+
 28-April-2017
 -------------
 

--- a/lecture_site/news_snippet.html
+++ b/lecture_site/news_snippet.html
@@ -1,14 +1,14 @@
 <div class="news clearfix">
 <h2>News</h2>
 <ul>
+<li><span class="date">23 May 2017</span> <a href="news/news.html#may-2017">Workshop on bayesian modeling with Jim Savage</a>
+<span class="summ">QuantEcon is sponsoring Jim Savage to present a workshop on bayesian modeling in Stan...</span></li>
+<li><span class="date">22 May 2017</span> <a href="news/news.html#may-2017">Introducing our 2017 summer intern</a>
+<span class="summ">QuantEcon welcomes our newest member, Trevor Lyon, who will be interning with us this summer...</span></li>
 <li><span class="date">28 Apr 2017</span> <a href="news/news.html#april-2017">Pandas for panel data</a>
 <span class="summ">An additional lecture on Pandas has been added that covers more advanced...</span></li>
 <li><span class="date">24 Apr 2017</span> <a href="news/news.html#april-2017">Statistics comparison cheatsheet</a>
 <span class="summ">If you're considering making the switch over to Pandas from STATA...</span></li>
-<li><span class="date">10 Apr 2017</span> <a href="news/news.html#april-2017">Sequential Analysis in Julia</a>
-<span class="summ">A Julia version of 'A Problem that Stumped Milton Friedman' is now available...</span></li>
-<li><span class="date">7 Apr 2017</span> <a href="news/news.html#april-2017">Endogenous Grid Method in Python and Julia</a>
-<span class="summ">We have added a new lecture on the endogenous grid method for policy...</span></li>
 </ul>
 <p class="more"><a href="/news/news.html">Read more QuantEcon news</a></p>
 </div>

--- a/news.yaml
+++ b/news.yaml
@@ -8,6 +8,33 @@
 #-
 #- Note: Ordering of Fields doesn't matter, sorting is done by date.
 #
+23-May-2017:
+  description: >
+    QuantEcon is sponsoring `Jim Savage <https://modernstatisticalworkflow.blogspot.com.au/>`__ 
+    to present a workshop on modern statistical workflow and bayesian modeling in 
+    `Stan <http://mc-stan.org/>__`. The workshop will be held at the Australian 
+    National University on 19 June. For more information, please see `here <https://quantecon.org/bayesian-workshop-2017.html>`__.
+  title: >
+    Workshop on bayesian modeling with Jim Savage
+  summary: >
+    QuantEcon is sponsoring Jim Savage to present a workshop on bayesian modeling in Stan...
+  website: >
+    lecture-site, org-site
+
+22-May-2017:
+  description: >
+    QuantEcon welcomes our newest member, `Trevor Lyon <https://github.com/tlyon3>`__, 
+    who is currently visiting the Australian National University in Canberra. 
+    Trevor is an undergraduate computer science student at Brigham Young University. 
+    He will be spending the summer working on various QuantEcon projects, 
+    including our new notebook publishing site.
+  title: >
+    Introducing our 2017 summer intern
+  summary: >
+    QuantEcon welcomes our newest member, Trevor Lyon, who will be interning with us this summer...
+  website: >
+    lecture-site, org-site
+
 
 28-April-2017:
   description: >

--- a/org_site/news.rst
+++ b/org_site/news.rst
@@ -6,6 +6,18 @@
 News & Announcements
 *************************
 
+23-May-2017
+-----------
+
+QuantEcon is sponsoring `Jim Savage <https://modernstatisticalworkflow.blogspot.com.au/>`__  to present a workshop on modern statistical workflow and bayesian modeling in  `Stan <http://mc-stan.org/>__`. The workshop will be held at the Australian  National University on 19 June. For more information, please see `here <https://quantecon.org/bayesian-workshop-2017.html>`__.
+
+
+22-May-2017
+-----------
+
+QuantEcon welcomes our newest member, `Trevor Lyon <https://github.com/tlyon3>`__,  who is currently visiting the Australian National University in Canberra.  Trevor is an undergraduate computer science student at Brigham Young University.  He will be spending the summer working on various QuantEcon projects,  including our new notebook publishing site.
+
+
 28-April-2017
 -------------
 

--- a/org_site/news_snippet.html
+++ b/org_site/news_snippet.html
@@ -1,12 +1,12 @@
 <div class="news clearfix">
 <h2>News</h2>
 <ul>
+<li><span class="date">23 May 2017</span> <a href="/news.html#may-2017">Workshop on bayesian modeling with Jim Savage</a>
+<span class="summ">QuantEcon is sponsoring Jim Savage to present a workshop on bayesian modeling in Stan...</span></li>
+<li><span class="date">22 May 2017</span> <a href="/news.html#may-2017">Introducing our 2017 summer intern</a>
+<span class="summ">QuantEcon welcomes our newest member, Trevor Lyon, who will be interning with us this summer...</span></li>
 <li><span class="date">28 Apr 2017</span> <a href="/news.html#april-2017">Pandas for panel data</a>
 <span class="summ">An additional lecture on Pandas has been added that covers more advanced...</span></li>
-<li><span class="date">24 Apr 2017</span> <a href="/news.html#april-2017">Statistics comparison cheatsheet</a>
-<span class="summ">If you're considering making the switch over to Pandas from STATA...</span></li>
-<li><span class="date">10 Apr 2017</span> <a href="/news.html#april-2017">Sequential Analysis in Julia</a>
-<span class="summ">A Julia version of 'A Problem that Stumped Milton Friedman' is now available...</span></li>
 </ul>
 <p class="more"><a href="news.html">Read more QuantEcon news</a></p>
 </div>


### PR DESCRIPTION
New platform won't be up for a week so I've added news items about:
1. Trevor joining us for the summer
2. Jim's upcoming workshop - which links to https://github.com/QuantEcon/QuantEcon.site/pull/90